### PR TITLE
Update/match namespace fixes

### DIFF
--- a/docs/core/plugins/development_basics.md
+++ b/docs/core/plugins/development_basics.md
@@ -224,7 +224,7 @@ Suppose you have an input plugin that gathers data and needs to output it for as
 
 ```python
 from pydantic import BaseModel
-from core.plugins import Result
+from opsbox import Result
 from pluggy import HookimplMarker
 
 hookimpl = HookimplMarker("opsbox")
@@ -254,7 +254,7 @@ class ExampleInputPlugin:
 In an assistant plugin, you can process the results from previous plugins:
 
 ```python
-from core.plugins import Result
+from opsbox import Result
 from pluggy import HookimplMarker
 
 hookimpl = HookimplMarker("opsbox")
@@ -282,7 +282,7 @@ class ExampleAssistantPlugin:
 Finally, an output plugin can take the processed results and output them accordingly:
 
 ```python
-from core.plugins import Result
+from opsbox import Result
 from pluggy import HookimplMarker
 
 hookimpl = HookimplMarker("opsbox")

--- a/docs/core/plugins/making_handlers.md
+++ b/docs/core/plugins/making_handlers.md
@@ -82,7 +82,7 @@ The `PluginInfo` object is a core component of the OpsBox Plugin System, encapsu
 **Example Usage:**
 
 ```python
-from core.plugins import PluginInfo
+from opsbox import PluginInfo
 
 plugin_info = PluginInfo(
     name="example_input",
@@ -102,7 +102,7 @@ By leveraging the `PluginInfo` object, developers can easily access and manage p
 ```python
 # general_handler.py
 from pluggy import HookimplMarker, PluginManager
-from core.plugins import PluginInfo, Result, Registry
+from opsbox import PluginInfo, Result, Registry
 from loguru import logger
 
 hookimpl = HookimplMarker("opsbox")
@@ -113,7 +113,7 @@ class GeneralHandler:
     @hookimpl
     def add_hookspecs(self, manager: PluginManager):
         """Add the hookspecs to the manager."""
-        from core.base_hooks import AssistantSpec, OutputSpec, ProviderSpec, InputSpec
+        from opsbox.base_hooks import AssistantSpec, OutputSpec, ProviderSpec, InputSpec
         manager.add_hookspecs(AssistantSpec)
         manager.add_hookspecs(OutputSpec)
         manager.add_hookspecs(ProviderSpec)
@@ -314,7 +314,7 @@ To extend the `HandlerSpec` with additional methods:
    ```python
    @hookimpl
    def add_hookspecs(self, manager: PluginManager):
-       from core.base_hooks import CustomSpec
+       from opsbox.base_hooks import CustomSpec
        manager.add_hookspecs(CustomSpec)
    ```
 

--- a/docs/core/plugins/making_outputs.md
+++ b/docs/core/plugins/making_outputs.md
@@ -36,7 +36,7 @@ Below is an example implementation of an output plugin that writes results to a 
 
 ```python
 from pluggy import HookimplMarker
-from core.plugins import Result
+from opsbox import Result
 import os
 
 hookimpl = HookimplMarker("opsbox")

--- a/docs/core/testing/testing_general_plugins.md
+++ b/docs/core/testing/testing_general_plugins.md
@@ -58,7 +58,7 @@ class InputSpec:
 
 ```python
 import pytest
-from core.plugins import PluginInfo, Result
+from opsbox import PluginInfo, Result
 from general_handler import GeneralHandler
 from mock_plugin_utils import MockPlugin, MockConfig
 

--- a/docs/core/testing/testing_rego_plugins.md
+++ b/docs/core/testing/testing_rego_plugins.md
@@ -78,7 +78,7 @@ This test simulates how a Rego plugin gathers data from a provider plugin and ap
 
 ```python
 import pytest
-from core.plugins import Result, PLuginFlow
+from opsbox import Result, PLuginFlow
 from rego_handler import RegoHandler
 from tests.mocks import MockPlugin, MockConfig
 


### PR DESCRIPTION
Match the new namespace fixes in versions 0.2.0 of opsbox and the rego handler